### PR TITLE
Render Pass API Refactor & Stencil Buffer Support

### DIFF
--- a/extensions/pl_graphics_ext.h
+++ b/extensions/pl_graphics_ext.h
@@ -169,7 +169,6 @@ typedef int plFormat;                 // -> enum _plFormat                 // En
 typedef int plStencilOp;              // -> enum _plStencilOp              // Enum:
 typedef int plMemoryMode;             // -> enum _plMemoryMode             // Enum:
 typedef int plLoadOperation;          // -> enum _plLoadOperation          // Enum:
-typedef int plSampleCount;            // -> enum _plSampleCount            // Enum:
 typedef int plLoadOp;                 // -> enum _plLoadOp                 // Enum:
 typedef int plStoreOp;                // -> enum _plStoreOp                // Enum:
 typedef int plTextureLayout;          // -> enum _plTextureLayout          // Enum:
@@ -419,7 +418,6 @@ typedef struct _plTextureDesc
     plFormat       tFormat;
     plTextureType  tType;
     plTextureUsage tUsage;
-    plSampleCount  tSamples;
 } plTextureDesc;
 
 typedef struct _plTexture
@@ -628,13 +626,11 @@ typedef struct _plSubpass
     uint32_t auRenderTargets[16];
     uint32_t auSubpassInputs[16];
     bool     bDepthTarget;
-    bool     bResolveTarget;
 } plSubpass;
 
 typedef struct _plDepthTarget
 {
     plFormat            tFormat;
-    plSampleCount       tSampleCount;
     plLoadOp            tLoadOp;
     plStoreOp           tStoreOp;
     plLoadOp            tStencilLoadOp;
@@ -647,7 +643,6 @@ typedef struct _plDepthTarget
 typedef struct _plRenderTarget
 {
     plFormat        tFormat;
-    plSampleCount   tSampleCount;
     plLoadOp        tLoadOp;
     plStoreOp       tStoreOp;
     plTextureLayout tNextUsage;
@@ -657,7 +652,6 @@ typedef struct _plRenderTarget
 typedef struct _plRenderPassLayoutDescription
 {
     plDepthTarget   tDepthTarget;
-    plRenderTarget  tResolveTarget;
     plRenderTarget  atRenderTargets[16];
     plSubpass       atSubpasses[16];
 } plRenderPassLayoutDescription;
@@ -665,7 +659,6 @@ typedef struct _plRenderPassLayoutDescription
 typedef struct _plRenderPassLayout
 {
     plRenderPassLayoutDescription tDesc;
-    plSampleCount                 tSampleCount;
 } plRenderPassLayout;
 
 typedef struct _plRenderPassAttachments
@@ -678,7 +671,6 @@ typedef struct _plRenderPassDescription
     plRenderPassLayoutHandle tLayout;
     plRenderTarget           atRenderTargets[16];
     plDepthTarget            tDepthTarget;
-    plRenderTarget           tResolveTarget;
     plVec2                   tDimensions;
     uint32_t                 uAttachmentCount;
     uint32_t                 uAttachmentSets;
@@ -703,16 +695,10 @@ typedef struct _plSwapchain
 {
     plExtent             tExtent;
     plFormat             tFormat;
-    plFormat             tDepthFormat;
     uint32_t             uImageCount;
     plTextureViewHandle* sbtSwapchainTextureViews;
-    plTextureHandle      tColorTexture;
-    plTextureViewHandle  tColorTextureView;
-    plTextureHandle      tDepthTexture;
-    plTextureViewHandle  tDepthTextureView;
     uint32_t             uCurrentImageIndex; // current image to use within the swap chain
     bool                 bVSync;
-    plSampleCount        tMsaaSamples;
 
     // platform specific
     void* _pInternalData;
@@ -736,6 +722,8 @@ typedef struct _plGraphics
     uint32_t*           sbtRenderPassLayoutFreeIndices;
 
     // render passes
+    plRenderPassLayoutHandle tMainRenderPassLayout;
+    plRenderPassHandle tMainRenderPass;
     plRenderPass* sbtRenderPassesCold;
     uint32_t*     sbtRenderPassGenerations;
     uint32_t*     sbtRenderPassFreeIndices;
@@ -924,7 +912,6 @@ enum _plStoreOp
 {
     PL_STORE_OP_STORE,
     PL_STORE_OP_DONT_CARE,
-    PL_STORE_OP_MULTISAMPLE_RESOLVE,
     PL_STORE_OP_NONE
 };
 
@@ -963,17 +950,6 @@ enum _plLoadOperation
     PL_LOAD_OPERATION_DONT_CARE,
     PL_LOAD_OPERATION_LOAD,
     PL_LOAD_OPERATION_CLEAR
-};
-
-enum _plSampleCount
-{
-    PL_SAMPLE_COUNT_1  = 1,
-    PL_SAMPLE_COUNT_2  = 2,
-    PL_SAMPLE_COUNT_4  = 4,
-    PL_SAMPLE_COUNT_8  = 8,
-    PL_SAMPLE_COUNT_16 = 16,
-    PL_SAMPLE_COUNT_32 = 32,
-    PL_SAMPLE_COUNT_64 = 64,
 };
 
 enum _plDataType

--- a/extensions/pl_ref_renderer_ext.h
+++ b/extensions/pl_ref_renderer_ext.h
@@ -36,6 +36,7 @@ typedef struct _plComponentLibrary plComponentLibrary; // pl_ecs_ext.h
 typedef struct _plCameraComponent  plCameraComponent;  // pl_ecs_ext.h
 typedef union _plMat4              plMat4;             // pl_math.h
 typedef union _plVec4              plVec4;             // pl_math.h
+typedef void* plTextureId;                             // pl_ui.h
 
 //-----------------------------------------------------------------------------
 // [SECTION] public api
@@ -65,19 +66,17 @@ typedef struct _plRefRendererI
     void (*submit_ui)(void);
     void (*cull_objects)(plCameraComponent*);
     void (*uncull_objects)(plCameraComponent*);
-    void (*submit_draw_stream)(plCameraComponent*);
     void (*draw_all_bound_boxes)(plDrawList3D*);
     void (*draw_visible_bound_boxes)(plDrawList3D*);
+    void (*submit_draw_stream)(plCameraComponent*);
     
     // misc
-    plRenderPassHandle  (*get_main_render_pass)(void);
     plComponentLibrary* (*get_component_library)(void);
     plGraphics*         (*get_graphics)(void);
 
     // temporary
-    void                (*show_offscreen)(bool* pbShow);
-    void                (*submit_offscreen_draw_stream)(plCameraComponent*);
-    plRenderPassHandle  (*get_pick_render_pass)(void);
+    plTextureId         (*get_offscreen_texture_id)(void);
+    plRenderPassHandle  (*get_offscreen_render_pass)(void);
 
 } plRefRendererI;
 


### PR DESCRIPTION
The removal of MSAA was necessary because the abstraction was gross (metal & vulkan handle it too differently to have a clean common API). By forcing everything to offscreen rendering, I was able to remove the code where a user creates the main renderpass for rendering to the swapchain (which is where MSAA happens) and instead gave the responsibility of creating the main renderpass back to the specific metal/vulkan backend. This significantly simplified the API. And in the future, adding MSAA back in the future will just be handled by passing some simple options when retrieving this main renderpass. Moving to complete offscreen rendering is necessary anyway for most graphics techniques.