### PR TITLE
feat: add coarse synchronization to graphics ext

### DIFF
--- a/extensions/pl_graphics_ext.c
+++ b/extensions/pl_graphics_ext.c
@@ -1174,6 +1174,8 @@ pl__cleanup_common_graphics(plGraphics* ptGraphics)
     pl_sb_free(ptGraphics->sbtComputeShaderGenerations);
     pl_sb_free(ptGraphics->sbtRenderPassLayoutGenerations);
     pl_sb_free(ptGraphics->sbtBindGroupFreeIndices);
+    pl_sb_free(ptGraphics->sbtSemaphoreGenerations);
+    pl_sb_free(ptGraphics->sbtSemaphoreFreeIndices);
 
     PL_FREE(ptGraphics->_pInternalData);
     PL_FREE(ptGraphics->tDevice._pInternalData);

--- a/extensions/pl_ref_renderer_ext.h
+++ b/extensions/pl_ref_renderer_ext.h
@@ -78,7 +78,7 @@ typedef struct _plRefRendererI
 
     // per frame
     void (*run_ecs)(void);
-    void (*update_scene)(uint32_t uSceneHandle);
+    void (*update_scene)(plCommandBuffer tCommandBuffer, uint32_t uSceneHandle);
     void (*render_scene)(plCommandBuffer tCommandBuffer, uint32_t uSceneHandle, uint32_t uViewHandle, plViewOptions tOptions);
     
     // misc


### PR DESCRIPTION
## Purpose
The main purpose of this pull request is to expose an API for coarse synchronization between the GPU/CPU and between command buffer submissions on the GPU. This allows a user the ability to do things like:
* asynchronous compute operations
* asynchronous transfer/blit operations
* overlap GPU work

## Background
Both Metal and Vulkan handle coarse synchronization in different ways and with different restrictions/freedoms.

## Points of Interests

### Encoders
In Vulkan, commands are recorded directly into a command buffer which allows the user to easily mix blit/compute/graphics work. This is not the case for Metal. In order to record commands into the command buffer, you must create blit/compute/graphics encoders. For our API, we will adopt this concept that although is a bit more restrictive, it only requires a user to consider work in stages.

### GPU<->GPU and GPU<->CPU Synchronization
Vulkan and Metal both have different sets of synchronization primitives with different capabilities and features. The most flexible primitive that fits our needs in Vulkan is the timeline semaphore. The closest primitive in Metal is a shared event for GPU<->CPU or an event for GPU<->GPU. All of these primitives allow the CPU to signal/wait/retrieve the semaphores value. They also allow you to submit work that waits on semaphores before starting and signals semaphores when finished. We abstract these away behind our a single "plSemaphore" object. There is a parameter when creating them that specifies whether or not you want the primitive to be host visible (which switches the metal backend to shared events).

### Wait/Signal Submission
In Vulkan, the wait/signal semaphores are submitted when a command buffer is sent to the queue for execution. In Metal, the waits are submitted before recording work to the command buffer and the signals are submitted after work. Therefore, in our API, we match the Metal API and just cache the wait semaphores for Vulkan.

### Internal Command Buffers
All backend specific command buffers are removed. This means the user has complete control now of scheduling work for the GPU. The exception are the ones used for image layout transitions in Vulkan. These will be handled in the future.

### Multiple Color Attachments in Render Passes
Added support for multiple color attachments in render passes. This allows a single shader to write to multiple color targets. This is useful for deferred rendering.

## Next Steps
The final big step left in the graphics extension for a 1.0 tag is adding support for subpasses and fine-grained synchronization (pipeline barriers). Subpasses basically allow you to describe all your renderpass attachments and dependencies which it will then handle pipeline barriers and image layout transitions for you. Subpasses will be straightforward for Vulkan since they are natively supported. For Metal, we will have to manually add the synchronization. Fine-grained synchronization will be even more straightforward as they are very similar in both APIs, with Metal being a bit more restrictive again.

Below you can see this an example of this current work in actions (before this work, all ops were in series). Once we add fine grained synchronization, users will be able orchestrate work within the batches.

![Picture1](https://github.com/hoffstadt/pilotlight/assets/39973752/4379bb90-cfd8-46e5-81b3-ea1e3e7f3c90)